### PR TITLE
Show all errors, and support comment blocks

### DIFF
--- a/dp_wizard_templates/code_template.py
+++ b/dp_wizard_templates/code_template.py
@@ -76,7 +76,7 @@ class Template:
 
         self._loop_kwargs(function, **kwargs)
 
-    def _fill_block_slots(self, **kwargs):
+    def _fill_block_slots(self, prefix_re, **kwargs):
         def function(k, v, errors):
             if not isinstance(v, str):
                 errors.append(f"for '{k}' slot, expected string, not '{v}'")
@@ -90,7 +90,7 @@ class Template:
 
             k_re = re.escape(k)
             self._template, count = re.subn(
-                rf"^([ \t]*){k_re}$",
+                rf"^([ \t]*{prefix_re}){k_re}$",
                 match_indent,
                 self._template,
                 flags=re.MULTILINE,
@@ -122,7 +122,14 @@ class Template:
         """
         Fill in code blocks. Slot must be alone on line.
         """
-        self._fill_block_slots(**kwargs)
+        self._fill_block_slots(r"", **kwargs)
+        return self
+
+    def fill_comment_blocks(self, **kwargs):
+        """
+        Fill in comment blocks. Slot must be commented.
+        """
+        self._fill_block_slots(r"#\s+", **kwargs)
         return self
 
     def finish(self, reformat=False) -> str:

--- a/dp_wizard_templates/code_template.py
+++ b/dp_wizard_templates/code_template.py
@@ -76,25 +76,7 @@ class Template:
 
         self._loop_kwargs(function, **kwargs)
 
-    def fill_expressions(self, **kwargs):
-        """
-        Fill in variable names, or dicts or lists represented as strings.
-        """
-        self._fill_inline_slots(str, **kwargs)
-        return self
-
-    def fill_values(self, **kwargs):
-        """
-        Fill in string or numeric values. `repr` is called before filling.
-        """
-        self._fill_inline_slots(repr, **kwargs)
-        return self
-
-    def fill_blocks(self, **kwargs):
-        """
-        Fill in code blocks. Slot must be alone on line.
-        """
-
+    def _fill_block_slots(self, **kwargs):
         def function(k, v, errors):
             if not isinstance(v, str):
                 errors.append(f"for '{k}' slot, expected string, not '{v}'")
@@ -121,6 +103,26 @@ class Template:
                     errors.append(base_message)
 
         self._loop_kwargs(function, **kwargs)
+
+    def fill_expressions(self, **kwargs):
+        """
+        Fill in variable names, or dicts or lists represented as strings.
+        """
+        self._fill_inline_slots(str, **kwargs)
+        return self
+
+    def fill_values(self, **kwargs):
+        """
+        Fill in string or numeric values. `repr` is called before filling.
+        """
+        self._fill_inline_slots(repr, **kwargs)
+        return self
+
+    def fill_code_blocks(self, **kwargs):
+        """
+        Fill in code blocks. Slot must be alone on line.
+        """
+        self._fill_block_slots(**kwargs)
         return self
 
     def finish(self, reformat=False) -> str:

--- a/dp_wizard_templates/code_template.py
+++ b/dp_wizard_templates/code_template.py
@@ -58,32 +58,28 @@ class Template:
     def _make_message(self, errors):
         return f"In {self._source}, " + ", ".join(errors) + f":\n{self._template}"
 
-    def fill_expressions(self, **kwargs):
-        """
-        Fill in variable names, or dicts or lists represented as strings.
-        """
+    def _fill(self, helper, **kwargs):
         errors = []
         for k, v in kwargs.items():
             k_re = re.escape(k)
-            self._template, count = re.subn(rf"\b{k_re}\b", str(v), self._template)
+            self._template, count = re.subn(rf"\b{k_re}\b", helper(v), self._template)
             if count == 0:
                 errors.append(f"no '{k}' slot to fill with '{v}'")
         if errors:
             raise Exception(self._make_message(errors))
+
+    def fill_expressions(self, **kwargs):
+        """
+        Fill in variable names, or dicts or lists represented as strings.
+        """
+        self._fill(str, **kwargs)
         return self
 
     def fill_values(self, **kwargs):
         """
         Fill in string or numeric values. `repr` is called before filling.
         """
-        errors = []
-        for k, v in kwargs.items():
-            k_re = re.escape(k)
-            self._template, count = re.subn(rf"\b{k_re}\b", repr(v), self._template)
-            if count == 0:
-                errors.append(f"no '{k}' slot to fill with '{v}'")
-        if errors:
-            raise Exception(self._make_message(errors))
+        self._fill(repr, **kwargs)
         return self
 
     def fill_blocks(self, **kwargs):

--- a/dp_wizard_templates/code_template.py
+++ b/dp_wizard_templates/code_template.py
@@ -59,34 +59,41 @@ class Template:
         """
         Fill in variable names, or dicts or lists represented as strings.
         """
+        errors = []
         for k, v in kwargs.items():
             k_re = re.escape(k)
             self._template, count = re.subn(rf"\b{k_re}\b", str(v), self._template)
             if count == 0:
-                raise Exception(
+                errors.append(
                     f"No '{k}' slot to fill with '{v}' in "
                     f"{self._source}:\n\n{self._template}"
                 )
+        if errors:
+            raise Exception("\n".join(errors))
         return self
 
     def fill_values(self, **kwargs):
         """
         Fill in string or numeric values. `repr` is called before filling.
         """
+        errors = []
         for k, v in kwargs.items():
             k_re = re.escape(k)
             self._template, count = re.subn(rf"\b{k_re}\b", repr(v), self._template)
             if count == 0:
-                raise Exception(
+                errors.append(
                     f"No '{k}' slot to fill with '{v}' in "
                     f"{self._source}:\n\n{self._template}"
                 )
+        if errors:
+            raise Exception("\n".join(errors))
         return self
 
     def fill_blocks(self, **kwargs):
         """
         Fill in code blocks. Slot must be alone on line.
         """
+        errors = []
         for k, v in kwargs.items():
             if not isinstance(v, str):
                 raise Exception(f"For {k} in {self._source}, expected string, not {v}")
@@ -110,10 +117,11 @@ class Template:
                     f"{self._source}:\n\n{self._template}"
                 )
                 if k in self._template:
-                    raise Exception(
-                        f"Block slots must be alone on line; {base_message}"
-                    )
-                raise Exception(base_message)
+                    errors.append(f"Block slots must be alone on line; {base_message}")
+                else:
+                    errors.append(base_message)
+        if errors:
+            raise Exception("\n".join(errors))
         return self
 
     def finish(self, reformat=False) -> str:

--- a/dp_wizard_templates/converters.py
+++ b/dp_wizard_templates/converters.py
@@ -30,7 +30,7 @@ class ConversionException(Exception):
 
 def convert_py_to_nb(
     python_str: str, title: str, execute: bool = False, reformat: bool = True
-):
+) -> str:
     """
     Given Python code as a string, returns a notebook as a string.
     Calls jupytext as a subprocess:
@@ -71,13 +71,13 @@ def convert_py_to_nb(
     return _clean_nb(json.dumps(nb_dict))
 
 
-def _stable_hash(lines: list[str]):
+def _stable_hash(lines: list[str]) -> str:
     import hashlib
 
     return hashlib.sha1("\n".join(lines).encode()).hexdigest()[:8]
 
 
-def _clean_nb(nb_json: str):
+def _clean_nb(nb_json: str) -> str:
     """
     Given a notebook as a string of JSON, remove the coda and pip output.
     (The code may produce reports that we do need,
@@ -104,7 +104,7 @@ def _clean_nb(nb_json: str):
     return json.dumps(nb, indent=1)
 
 
-def convert_nb_to_html(python_nb: str, numbered=True):
+def convert_nb_to_html(python_nb: str, numbered=True) -> str:
     notebook = nbformat.reads(python_nb, as_version=4)
     exporter = nbconvert.HTMLExporter(
         template_name="lab",

--- a/examples/_block_demo.py
+++ b/examples/_block_demo.py
@@ -2,4 +2,5 @@ def FUNCTION_NAME(PARAMS):
     """
     This demonstrates how larger blocks of code can be built compositionally.
     """
+    # COMMENT
     INNER_BLOCK

--- a/examples/hello-world.html
+++ b/examples/hello-world.html
@@ -7523,7 +7523,7 @@ even though the lines are not contiguous</p>
 </div>
 </div>
 </div>
-</div><div class="jp-Cell jp-CodeCell jp-Notebook-cell" id="cell-id=bbe7eb3d">
+</div><div class="jp-Cell jp-CodeCell jp-Notebook-cell" id="cell-id=d75dbbc1">
 <div class="jp-Cell-inputWrapper" tabindex="0">
 <div class="jp-Collapser jp-InputCollapser jp-Cell-inputCollapser">
 </div>
@@ -7535,6 +7535,9 @@ even though the lines are not contiguous</p>
 <span class="w">    </span><span class="sd">"""</span>
 <span class="sd">    This demonstrates how larger blocks of code can be built compositionally.</span>
 <span class="sd">    """</span>
+    <span class="c1"># Water freezes at:</span>
+    <span class="c1"># 32 Fahrenheit</span>
+    <span class="c1"># 0 Celsius</span>
     <span class="k">if</span> <span class="n">temp_c</span> <span class="o">&lt;</span> <span class="mi">0</span><span class="p">:</span>
         <span class="nb">print</span><span class="p">(</span><span class="s2">"It is freezing!"</span><span class="p">)</span>
 

--- a/examples/hello-world.ipynb
+++ b/examples/hello-world.ipynb
@@ -17,7 +17,7 @@
   {
    "cell_type": "code",
    "execution_count": 1,
-   "id": "bbe7eb3d",
+   "id": "d75dbbc1",
    "metadata": {},
    "outputs": [
     {
@@ -33,6 +33,9 @@
     "    \"\"\"\n",
     "    This demonstrates how larger blocks of code can be built compositionally.\n",
     "    \"\"\"\n",
+    "    # Water freezes at:\n",
+    "    # 32 Fahrenheit\n",
+    "    # 0 Celsius\n",
     "    if temp_c < 0:\n",
     "        print(\"It is freezing!\")\n",
     "\n",

--- a/index.html
+++ b/index.html
@@ -7597,7 +7597,7 @@ can be parsed, they should not be imported or executed as-is.)</p>
 </div>
 </div>
 </div>
-</div><div class="jp-Cell jp-CodeCell jp-Notebook-cell jp-mod-noOutputs" id="cell-id=4fd80ead">
+</div><div class="jp-Cell jp-CodeCell jp-Notebook-cell jp-mod-noOutputs" id="cell-id=1500d30c">
 <div class="jp-Cell-inputWrapper" tabindex="0">
 <div class="jp-Collapser jp-InputCollapser jp-Cell-inputCollapser">
 </div>
@@ -7612,7 +7612,7 @@ can be parsed, they should not be imported or executed as-is.)</p>
 <span class="n">block_demo</span> <span class="o">=</span> <span class="p">(</span>
     <span class="n">Template</span><span class="p">(</span><span class="s2">"block_demo"</span><span class="p">,</span> <span class="n">root</span><span class="o">=</span><span class="n">root</span> <span class="o">/</span> <span class="s2">"examples"</span><span class="p">)</span>
     <span class="o">.</span><span class="n">fill_expressions</span><span class="p">(</span><span class="n">FUNCTION_NAME</span><span class="o">=</span><span class="s2">"freeze_warning"</span><span class="p">,</span> <span class="n">PARAMS</span><span class="o">=</span><span class="s2">"temp_c"</span><span class="p">)</span>
-    <span class="o">.</span><span class="n">fill_blocks</span><span class="p">(</span><span class="n">INNER_BLOCK</span><span class="o">=</span><span class="n">conditional_print</span><span class="p">)</span>
+    <span class="o">.</span><span class="n">fill_code_blocks</span><span class="p">(</span><span class="n">INNER_BLOCK</span><span class="o">=</span><span class="n">conditional_print</span><span class="p">)</span>
     <span class="o">.</span><span class="n">finish</span><span class="p">()</span>
 <span class="p">)</span>
 
@@ -7683,7 +7683,7 @@ to produce other artifacts without adding clutter.</p>
 </div>
 </div>
 </div>
-</div><div class="jp-Cell jp-CodeCell jp-Notebook-cell jp-mod-noOutputs" id="cell-id=b5dc8879">
+</div><div class="jp-Cell jp-CodeCell jp-Notebook-cell jp-mod-noOutputs" id="cell-id=ccf10f98">
 <div class="jp-Cell-inputWrapper" tabindex="0">
 <div class="jp-Collapser jp-InputCollapser jp-Cell-inputCollapser">
 </div>
@@ -7720,7 +7720,7 @@ to produce other artifacts without adding clutter.</p>
 <span class="n">title</span> <span class="o">=</span> <span class="s2">"Hello World!"</span>
 <span class="n">notebook_py</span> <span class="o">=</span> <span class="p">(</span>
     <span class="n">Template</span><span class="p">(</span><span class="n">notebook_template</span><span class="p">)</span>
-    <span class="o">.</span><span class="n">fill_blocks</span><span class="p">(</span><span class="n">BLOCK</span><span class="o">=</span><span class="n">block_demo</span><span class="p">)</span>
+    <span class="o">.</span><span class="n">fill_code_blocks</span><span class="p">(</span><span class="n">BLOCK</span><span class="o">=</span><span class="n">block_demo</span><span class="p">)</span>
     <span class="o">.</span><span class="n">fill_expressions</span><span class="p">(</span><span class="n">FUNCTION_NAME</span><span class="o">=</span><span class="s2">"freeze_warning"</span><span class="p">,</span> <span class="n">TITLE</span><span class="o">=</span><span class="n">title</span><span class="p">)</span>
     <span class="o">.</span><span class="n">finish</span><span class="p">()</span>
 <span class="p">)</span>

--- a/index.html
+++ b/index.html
@@ -7574,13 +7574,18 @@ itself can be parsed as Python code, so syntax highlighting and linting still wo
 </div>
 </div>
 </div>
-<div class="jp-Cell jp-MarkdownCell jp-Notebook-cell" id="cell-id=debe102a">
+<div class="jp-Cell jp-MarkdownCell jp-Notebook-cell" id="cell-id=39e34438">
 <div class="jp-Cell-inputWrapper" tabindex="0">
 <div class="jp-Collapser jp-InputCollapser jp-Cell-inputCollapser">
 </div>
 <div class="jp-InputArea jp-Cell-inputArea"><div class="jp-InputPrompt jp-InputArea-prompt">
 </div><div class="jp-RenderedHTMLCommon jp-RenderedMarkdown jp-MarkdownOutput" data-mime-type="text/markdown">
-<p>Note the different methods used:</p>
+<p>Note that <code>conditional_print_template</code> is not called: Instead,
+the <code>inspect</code> package is used to load its source, and the slots
+in all-caps are filled. Including a parameter list is optional,
+but providing args which match the names of your slots can prevent
+warnings from your IDE.</p>
+<p>Different methods are available on the <code>Template</code> object:</p>
 <ul>
 <li><code>fill_expressions()</code> fills the slot with verbatim text.
 It can be used for an expression like this, or for variable names.</li>
@@ -7590,14 +7595,15 @@ data structure, as long as it has a usable repr.</li>
 <li><code>finish()</code> converts the template to a string, and will error
 if not all slots have been filled.</li>
 </ul>
-<p>Templates can also be in standalone files. If a <code>root</code> parameter is provided,
+<p>(The next section will introduce <code>fill_code_block()</code> and <code>fill_comment_block()</code>.)</p>
+<p>Templates can also be standalone files. If a <code>root</code> parameter is provided,
 the system will prepend <code>_</code> and append <code>.py</code> and look for a corresponding file.
 (The convention of prepending <code>_</code> reminds us that although these files
 can be parsed, they should not be imported or executed as-is.)</p>
 </div>
 </div>
 </div>
-</div><div class="jp-Cell jp-CodeCell jp-Notebook-cell jp-mod-noOutputs" id="cell-id=1500d30c">
+</div><div class="jp-Cell jp-CodeCell jp-Notebook-cell jp-mod-noOutputs" id="cell-id=589cc13d">
 <div class="jp-Cell-inputWrapper" tabindex="0">
 <div class="jp-Collapser jp-InputCollapser jp-Cell-inputCollapser">
 </div>
@@ -7613,6 +7619,9 @@ can be parsed, they should not be imported or executed as-is.)</p>
     <span class="n">Template</span><span class="p">(</span><span class="s2">"block_demo"</span><span class="p">,</span> <span class="n">root</span><span class="o">=</span><span class="n">root</span> <span class="o">/</span> <span class="s2">"examples"</span><span class="p">)</span>
     <span class="o">.</span><span class="n">fill_expressions</span><span class="p">(</span><span class="n">FUNCTION_NAME</span><span class="o">=</span><span class="s2">"freeze_warning"</span><span class="p">,</span> <span class="n">PARAMS</span><span class="o">=</span><span class="s2">"temp_c"</span><span class="p">)</span>
     <span class="o">.</span><span class="n">fill_code_blocks</span><span class="p">(</span><span class="n">INNER_BLOCK</span><span class="o">=</span><span class="n">conditional_print</span><span class="p">)</span>
+    <span class="o">.</span><span class="n">fill_comment_blocks</span><span class="p">(</span>
+        <span class="n">COMMENT</span><span class="o">=</span><span class="s2">"Water freezes at:</span><span class="se">\n</span><span class="s2">32 Fahrenheit</span><span class="se">\n</span><span class="s2">0 Celsius"</span>
+    <span class="p">)</span>
     <span class="o">.</span><span class="n">finish</span><span class="p">()</span>
 <span class="p">)</span>
 
@@ -7622,6 +7631,9 @@ can be parsed, they should not be imported or executed as-is.)</p>
 <span class="s1">    """</span>
 <span class="s1">    This demonstrates how larger blocks of code can be built compositionally.</span>
 <span class="s1">    """</span>
+<span class="s1">    # Water freezes at:</span>
+<span class="s1">    # 32 Fahrenheit</span>
+<span class="s1">    # 0 Celsius</span>
 <span class="s1">    if temp_c &lt; 0:</span>
 <span class="s1">        print('It is freezing!')</span>
 <span class="s1">'''</span>

--- a/index.html
+++ b/index.html
@@ -7603,7 +7603,7 @@ can be parsed, they should not be imported or executed as-is.)</p>
 </div>
 </div>
 </div>
-</div><div class="jp-Cell jp-CodeCell jp-Notebook-cell jp-mod-noOutputs" id="cell-id=589cc13d">
+</div><div class="jp-Cell jp-CodeCell jp-Notebook-cell jp-mod-noOutputs" id="cell-id=c3374f03">
 <div class="jp-Cell-inputWrapper" tabindex="0">
 <div class="jp-Collapser jp-InputCollapser jp-Cell-inputCollapser">
 </div>
@@ -7620,7 +7620,11 @@ can be parsed, they should not be imported or executed as-is.)</p>
     <span class="o">.</span><span class="n">fill_expressions</span><span class="p">(</span><span class="n">FUNCTION_NAME</span><span class="o">=</span><span class="s2">"freeze_warning"</span><span class="p">,</span> <span class="n">PARAMS</span><span class="o">=</span><span class="s2">"temp_c"</span><span class="p">)</span>
     <span class="o">.</span><span class="n">fill_code_blocks</span><span class="p">(</span><span class="n">INNER_BLOCK</span><span class="o">=</span><span class="n">conditional_print</span><span class="p">)</span>
     <span class="o">.</span><span class="n">fill_comment_blocks</span><span class="p">(</span>
-        <span class="n">COMMENT</span><span class="o">=</span><span class="s2">"Water freezes at:</span><span class="se">\n</span><span class="s2">32 Fahrenheit</span><span class="se">\n</span><span class="s2">0 Celsius"</span>
+        <span class="n">COMMENT</span><span class="o">=</span><span class="s2">"""</span>
+<span class="s2">        Water freezes at:</span>
+<span class="s2">        32 Fahrenheit</span>
+<span class="s2">        0 Celsius</span>
+<span class="s2">        """</span>
     <span class="p">)</span>
     <span class="o">.</span><span class="n">finish</span><span class="p">()</span>
 <span class="p">)</span>

--- a/tests/test_code_template.py
+++ b/tests/test_code_template.py
@@ -97,18 +97,27 @@ def test_fill_blocks():
 FIRST
 
 with fake:
-    SECOND
+    my_tuple = (
+        # SECOND
+        VALUE,
+    )
     if True:
         THIRD
 """,
     )
-    template.fill_code_blocks(
-        FIRST="\n".join(f"import {i}" for i in "abc"),
-        SECOND="\n".join(f"f({i})" for i in "123"),
-        THIRD="\n".join(f"{i}()" for i in "xyz"),
+    filled = (
+        template.fill_code_blocks(
+            FIRST="\n".join(f"import {i}" for i in "abc"),
+            THIRD="\n".join(f"{i}()" for i in "xyz"),
+        )
+        .fill_comment_blocks(
+            SECOND="This is a\nmulti-line comment",
+        )
+        .fill_values(VALUE=42)
+        .finish()
     )
     assert (
-        template.finish()
+        filled
         == """# MixedCase is OK
 
 import a
@@ -116,9 +125,11 @@ import b
 import c
 
 with fake:
-    f(1)
-    f(2)
-    f(3)
+    my_tuple = (
+        # This is a
+        # multi-line comment
+        42,
+    )
     if True:
         x()
         y()

--- a/tests/test_code_template.py
+++ b/tests/test_code_template.py
@@ -37,9 +37,9 @@ def test_fill_expressions_missing_slots_in_template():
     template = Template("No one ... the ... ...!")
     with pytest.raises(
         Exception,
-        match=r"no 'VERB' slot to fill with 'expects', "
-        r"no 'ADJ' slot to fill with 'Spanish', "
-        r"no 'NOUN' slot to fill with 'Inquisition'",
+        match=r"no 'ADJ' slot to fill with 'Spanish', "
+        r"no 'NOUN' slot to fill with 'Inquisition', "
+        r"no 'VERB' slot to fill with 'expects':",
     ):
         template.fill_expressions(
             VERB="expects",

--- a/tests/test_code_template.py
+++ b/tests/test_code_template.py
@@ -102,7 +102,7 @@ with fake:
         THIRD
 """,
     )
-    template.fill_blocks(
+    template.fill_code_blocks(
         FIRST="\n".join(f"import {i}" for i in "abc"),
         SECOND="\n".join(f"f({i})" for i in "123"),
         THIRD="\n".join(f"{i}()" for i in "xyz"),
@@ -130,7 +130,7 @@ with fake:
 def test_fill_blocks_missing_slot_in_template_alone():
     template = Template("No block slot")
     with pytest.raises(Exception, match=r"no 'SLOT' slot to fill with 'placeholder':"):
-        template.fill_blocks(SLOT="placeholder").finish()
+        template.fill_code_blocks(SLOT="placeholder").finish()
 
 
 def test_fill_blocks_missing_slot_in_template_not_alone():
@@ -140,13 +140,13 @@ def test_fill_blocks_missing_slot_in_template_not_alone():
         match=r"no 'SLOT' slot to fill with 'placeholder' "
         r"\(block slots must be alone on line\)",
     ):
-        template.fill_blocks(SLOT="placeholder").finish()
+        template.fill_code_blocks(SLOT="placeholder").finish()
 
 
 def test_fill_blocks_extra_slot_in_template():
     template = Template("EXTRA\nSLOT")
     with pytest.raises(Exception, match=r"'EXTRA' slot not filled"):
-        template.fill_blocks(SLOT="placeholder").finish()
+        template.fill_code_blocks(SLOT="placeholder").finish()
 
 
 def test_fill_blocks_not_string():
@@ -155,4 +155,4 @@ def test_fill_blocks_not_string():
         Exception,
         match=r"for 'SOMETHING' slot, expected string, not '123'",
     ):
-        template.fill_blocks(SOMETHING=123).finish()
+        template.fill_code_blocks(SOMETHING=123).finish()

--- a/tests/test_code_template.py
+++ b/tests/test_code_template.py
@@ -33,9 +33,14 @@ def test_fill_expressions():
     assert filled == "No one expects the Spanish Inquisition!"
 
 
-def test_fill_expressions_missing_slot_in_template():
-    template = Template("No one ... the ADJ NOUN!")
-    with pytest.raises(Exception, match=r"No 'VERB' slot to fill with 'expects'"):
+def test_fill_expressions_missing_slots_in_template():
+    template = Template("No one ... the ... ...!")
+    with pytest.raises(
+        Exception,
+        match=r"no 'VERB' slot to fill with 'expects', "
+        r"no 'ADJ' slot to fill with 'Spanish', "
+        r"no 'NOUN' slot to fill with 'Inquisition'",
+    ):
         template.fill_expressions(
             VERB="expects",
             ADJ="Spanish",
@@ -43,11 +48,12 @@ def test_fill_expressions_missing_slot_in_template():
         ).finish()
 
 
-def test_fill_expressions_extra_slot_in_template():
+def test_fill_expressions_extra_slots_in_template():
     template = Template("No one VERB ARTICLE ADJ NOUN!")
-    with pytest.raises(Exception, match=r"'ARTICLE' slot not filled"):
+    with pytest.raises(
+        Exception, match=r"'ARTICLE' slot not filled, 'VERB' slot not filled"
+    ):
         template.fill_expressions(
-            VERB="expects",
             ADJ="Spanish",
             NOUN="Inquisition",
         ).finish()
@@ -65,7 +71,7 @@ def test_fill_values():
 
 def test_fill_values_missing_slot_in_template():
     template = Template("assert [STRING] * ... == LIST")
-    with pytest.raises(Exception, match=r"No 'NUM' slot to fill with '3'"):
+    with pytest.raises(Exception, match=r"no 'NUM' slot to fill with '3'"):
         template.fill_values(
             STRING="🙂",
             NUM=3,
@@ -123,14 +129,16 @@ with fake:
 
 def test_fill_blocks_missing_slot_in_template_alone():
     template = Template("No block slot")
-    with pytest.raises(Exception, match=r"No 'SLOT' slot"):
+    with pytest.raises(Exception, match=r"no 'SLOT' slot to fill with 'placeholder':"):
         template.fill_blocks(SLOT="placeholder").finish()
 
 
 def test_fill_blocks_missing_slot_in_template_not_alone():
     template = Template("No block SLOT")
     with pytest.raises(
-        Exception, match=r"Block slots must be alone on line; No 'SLOT' slot"
+        Exception,
+        match=r"no 'SLOT' slot to fill with 'placeholder' "
+        r"\(block slots must be alone on line\)",
     ):
         template.fill_blocks(SLOT="placeholder").finish()
 
@@ -145,6 +153,6 @@ def test_fill_blocks_not_string():
     template = Template("SOMETHING")
     with pytest.raises(
         Exception,
-        match=r"For SOMETHING in string template, expected string, not 123",
+        match=r"for 'SOMETHING' slot, expected string, not '123'",
     ):
         template.fill_blocks(SOMETHING=123).finish()

--- a/tests/test_index_html.py
+++ b/tests/test_index_html.py
@@ -77,7 +77,7 @@ root = Path(__file__).parent.parent
 block_demo = (
     Template("block_demo", root=root / "examples")
     .fill_expressions(FUNCTION_NAME="freeze_warning", PARAMS="temp_c")
-    .fill_blocks(INNER_BLOCK=conditional_print)
+    .fill_code_blocks(INNER_BLOCK=conditional_print)
     .finish()
 )
 
@@ -152,7 +152,7 @@ def notebook_template(TITLE, BLOCK, FUNCTION_NAME):
 title = "Hello World!"
 notebook_py = (
     Template(notebook_template)
-    .fill_blocks(BLOCK=block_demo)
+    .fill_code_blocks(BLOCK=block_demo)
     .fill_expressions(FUNCTION_NAME="freeze_warning", TITLE=title)
     .finish()
 )

--- a/tests/test_index_html.py
+++ b/tests/test_index_html.py
@@ -54,7 +54,13 @@ assert conditional_print == "if temp_c < 0:\n    print('It is freezing!')"
 
 # -
 
-# Note the different methods used:
+# Note that `conditional_print_template` is not called: Instead,
+# the `inspect` package is used to load its source, and the slots
+# in all-caps are filled. Including a parameter list is optional,
+# but providing args which match the names of your slots can prevent
+# warnings from your IDE.
+#
+# Different methods are available on the `Template` object:
 # - `fill_expressions()` fills the slot with verbatim text.
 #   It can be used for an expression like this, or for variable names.
 # - `fill_values()` fills the slot with the repr of the provided value.
@@ -63,7 +69,9 @@ assert conditional_print == "if temp_c < 0:\n    print('It is freezing!')"
 # - `finish()` converts the template to a string, and will error
 #   if not all slots have been filled.
 #
-# Templates can also be in standalone files. If a `root` parameter is provided,
+# (The next section will introduce `fill_code_block()` and `fill_comment_block()`.)
+#
+# Templates can also be standalone files. If a `root` parameter is provided,
 # the system will prepend `_` and append `.py` and look for a corresponding file.
 # (The convention of prepending `_` reminds us that although these files
 # can be parsed, they should not be imported or executed as-is.)
@@ -78,6 +86,7 @@ block_demo = (
     Template("block_demo", root=root / "examples")
     .fill_expressions(FUNCTION_NAME="freeze_warning", PARAMS="temp_c")
     .fill_code_blocks(INNER_BLOCK=conditional_print)
+    .fill_comment_blocks(COMMENT="Water freezes at:\n32 Fahrenheit\n0 Celsius")
     .finish()
 )
 
@@ -87,6 +96,9 @@ assert (
     """
     This demonstrates how larger blocks of code can be built compositionally.
     """
+    # Water freezes at:
+    # 32 Fahrenheit
+    # 0 Celsius
     if temp_c < 0:
         print('It is freezing!')
 '''

--- a/tests/test_index_html.py
+++ b/tests/test_index_html.py
@@ -86,7 +86,13 @@ block_demo = (
     Template("block_demo", root=root / "examples")
     .fill_expressions(FUNCTION_NAME="freeze_warning", PARAMS="temp_c")
     .fill_code_blocks(INNER_BLOCK=conditional_print)
-    .fill_comment_blocks(COMMENT="Water freezes at:\n32 Fahrenheit\n0 Celsius")
+    .fill_comment_blocks(
+        COMMENT="""
+        Water freezes at:
+        32 Fahrenheit
+        0 Celsius
+        """
+    )
     .finish()
 )
 


### PR DESCRIPTION
- Fix #9 
- Fix #10
- A lot of refactoring to pull out shared logic between the different fill functions
- Add py.typed, and fill in the signatures
- Update the generated index.html with a comment block example